### PR TITLE
feat: Add Claude (Anthropic) LLM adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
-  "name": "@ucptools/agent-sdk",
+  "name": "@agorio/sdk",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ucptools/agent-sdk",
+      "name": "@agorio/sdk",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.77.0",
         "@google/generative-ai": "^0.24.0"
       },
       "devDependencies": {
@@ -28,6 +29,35 @@
         "express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.77.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.77.0.tgz",
+      "integrity": "sha512-TivlT6nfidz3sOyMF72T2x5AkmHrpT7JgL2e/0HNdh7b24v7JC8cR+rCY/42jA68xIsjmiGQ5IKMsH9feEKh3A==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1666,6 +1696,19 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2253,6 +2296,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.77.0",
     "@google/generative-ai": "^0.24.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,8 @@ export { UcpClient, UcpDiscoveryError, UcpApiError } from './client/ucp-client.j
 // LLM adapters
 export { GeminiAdapter } from './llm/gemini.js';
 export type { GeminiAdapterOptions } from './llm/gemini.js';
+export { ClaudeAdapter } from './llm/claude.js';
+export type { ClaudeAdapterOptions } from './llm/claude.js';
 
 // Agent
 export { ShoppingAgent } from './agent/shopping-agent.js';

--- a/src/llm/claude.ts
+++ b/src/llm/claude.ts
@@ -1,0 +1,204 @@
+/**
+ * Claude (Anthropic) LLM Adapter
+ *
+ * Integrates Anthropic Claude with tool use support
+ * for UCP shopping agent operations.
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import type {
+  LlmAdapter,
+  ChatMessage,
+  ToolDefinition,
+  ToolCall,
+  LlmResponse,
+} from '../types/index.js';
+
+export interface ClaudeAdapterOptions {
+  /** Anthropic API key */
+  apiKey: string;
+  /** Model name (default: claude-sonnet-4-20250514) */
+  model?: string;
+  /** System prompt for the model */
+  systemPrompt?: string;
+  /** Temperature (0-1, default: 0.7) */
+  temperature?: number;
+  /** Maximum tokens to generate (default: 4096) */
+  maxTokens?: number;
+}
+
+export class ClaudeAdapter implements LlmAdapter {
+  private readonly client: Anthropic;
+  readonly modelName: string;
+  private readonly systemPrompt: string;
+  private readonly temperature: number;
+  private readonly maxTokens: number;
+
+  constructor(options: ClaudeAdapterOptions) {
+    this.client = new Anthropic({ apiKey: options.apiKey });
+    this.modelName = options.model ?? 'claude-sonnet-4-20250514';
+    this.systemPrompt = options.systemPrompt ?? this.getDefaultSystemPrompt();
+    this.temperature = options.temperature ?? 0.7;
+    this.maxTokens = options.maxTokens ?? 4096;
+  }
+
+  async chat(messages: ChatMessage[], tools?: ToolDefinition[]): Promise<LlmResponse> {
+    const anthropicMessages = this.toAnthropicMessages(messages);
+    const anthropicTools = tools?.length ? this.toAnthropicTools(tools) : undefined;
+
+    const response = await this.client.messages.create({
+      model: this.modelName,
+      max_tokens: this.maxTokens,
+      system: this.systemPrompt,
+      messages: anthropicMessages,
+      ...(anthropicTools ? { tools: anthropicTools } : {}),
+      temperature: this.temperature,
+    });
+
+    return this.parseResponse(response);
+  }
+
+  // ─── Internal helpers ───
+
+  private toAnthropicMessages(messages: ChatMessage[]): Anthropic.MessageParam[] {
+    const result: Anthropic.MessageParam[] = [];
+    // Track tool call IDs: tool name → queue of IDs (for resolving name-based toolCallId)
+    const toolIdQueues = new Map<string, string[]>();
+
+    for (const msg of messages) {
+      if (msg.role === 'system') continue;
+
+      if (msg.role === 'user') {
+        result.push({ role: 'user', content: msg.content });
+        continue;
+      }
+
+      if (msg.role === 'assistant') {
+        const contentBlocks: Anthropic.ContentBlockParam[] = [];
+
+        if (msg.content) {
+          contentBlocks.push({ type: 'text', text: msg.content });
+        }
+
+        if (msg.toolCalls) {
+          for (const tc of msg.toolCalls) {
+            contentBlocks.push({
+              type: 'tool_use',
+              id: tc.id,
+              name: tc.name,
+              input: tc.arguments,
+            });
+            // Enqueue this ID for later resolution
+            if (!toolIdQueues.has(tc.name)) {
+              toolIdQueues.set(tc.name, []);
+            }
+            toolIdQueues.get(tc.name)!.push(tc.id);
+          }
+        }
+
+        if (contentBlocks.length > 0) {
+          result.push({ role: 'assistant', content: contentBlocks });
+        }
+        continue;
+      }
+
+      if (msg.role === 'tool') {
+        // Resolve tool_use_id: ShoppingAgent sets toolCallId to tool NAME,
+        // but Anthropic requires the actual tool_use block ID.
+        let toolUseId = msg.toolCallId ?? 'unknown';
+
+        const queue = toolIdQueues.get(toolUseId);
+        if (queue && queue.length > 0) {
+          toolUseId = queue.shift()!;
+        }
+
+        const toolResultBlock: Anthropic.ToolResultBlockParam = {
+          type: 'tool_result',
+          tool_use_id: toolUseId,
+          content: msg.content,
+        };
+
+        // Merge consecutive tool results into a single user message
+        // (Anthropic requires strict role alternation)
+        const last = result[result.length - 1];
+        if (last && last.role === 'user' && Array.isArray(last.content)) {
+          (last.content as Anthropic.ToolResultBlockParam[]).push(toolResultBlock);
+        } else {
+          result.push({ role: 'user', content: [toolResultBlock] });
+        }
+        continue;
+      }
+    }
+
+    return result;
+  }
+
+  private toAnthropicTools(tools: ToolDefinition[]): Anthropic.Tool[] {
+    return tools.map(tool => ({
+      name: tool.name,
+      description: tool.description,
+      input_schema: {
+        type: 'object' as const,
+        properties: (tool.parameters as Record<string, unknown>).properties ?? {},
+        required: ((tool.parameters as Record<string, unknown>).required ?? []) as string[],
+      },
+    }));
+  }
+
+  private parseResponse(response: Anthropic.Message): LlmResponse {
+    const textParts: string[] = [];
+    const toolCalls: ToolCall[] = [];
+
+    for (const block of response.content) {
+      if (block.type === 'text') {
+        textParts.push(block.text);
+      }
+      if (block.type === 'tool_use') {
+        toolCalls.push({
+          id: block.id,
+          name: block.name,
+          arguments: block.input as Record<string, unknown>,
+        });
+      }
+    }
+
+    let finishReason: LlmResponse['finishReason'];
+    switch (response.stop_reason) {
+      case 'end_turn':
+        finishReason = 'stop';
+        break;
+      case 'tool_use':
+        finishReason = 'tool_calls';
+        break;
+      case 'max_tokens':
+        finishReason = 'length';
+        break;
+      default:
+        finishReason = toolCalls.length > 0 ? 'tool_calls' : 'stop';
+    }
+
+    return {
+      content: textParts.join(''),
+      toolCalls,
+      finishReason,
+      usage: {
+        promptTokens: response.usage.input_tokens,
+        completionTokens: response.usage.output_tokens,
+        totalTokens: response.usage.input_tokens + response.usage.output_tokens,
+      },
+    };
+  }
+
+  private getDefaultSystemPrompt(): string {
+    return `You are a UCP Shopping Agent — an AI assistant that helps users discover and purchase products from UCP-enabled merchants.
+
+You interact with merchants through the Universal Commerce Protocol (UCP). Your workflow:
+1. Discover the merchant by fetching their UCP profile
+2. Browse their product catalog
+3. Help the user find what they need
+4. Complete the checkout process when requested
+
+Always be helpful, transparent about prices, and confirm before completing purchases.
+When you have enough information to proceed, use the available tools. When you need clarification, ask the user.`;
+  }
+}

--- a/tests/claude-adapter.test.ts
+++ b/tests/claude-adapter.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Tests for ClaudeAdapter - Anthropic Claude LLM integration
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ClaudeAdapter } from '../src/llm/claude.js';
+import type { ChatMessage, ToolDefinition, ToolCall } from '../src/types/index.js';
+
+// Mock the Anthropic SDK
+const mockCreate = vi.fn();
+
+vi.mock('@anthropic-ai/sdk', () => {
+  return {
+    default: class MockAnthropic {
+      messages = { create: mockCreate };
+      constructor(_opts?: unknown) {}
+    },
+  };
+});
+
+function makeAnthropicResponse(overrides: {
+  content?: Array<{ type: string; text?: string; id?: string; name?: string; input?: unknown }>;
+  stop_reason?: string;
+  usage?: { input_tokens: number; output_tokens: number };
+}) {
+  return {
+    id: 'msg_test',
+    type: 'message',
+    role: 'assistant',
+    model: 'claude-sonnet-4-20250514',
+    content: overrides.content ?? [{ type: 'text', text: 'Hello' }],
+    stop_reason: overrides.stop_reason ?? 'end_turn',
+    usage: overrides.usage ?? { input_tokens: 10, output_tokens: 5 },
+  };
+}
+
+describe('ClaudeAdapter', () => {
+  let adapter: ClaudeAdapter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new ClaudeAdapter({ apiKey: 'test-key' });
+  });
+
+  // ─── Constructor ───
+
+  describe('constructor', () => {
+    it('should set default model name', () => {
+      expect(adapter.modelName).toBe('claude-sonnet-4-20250514');
+    });
+
+    it('should accept custom model name', () => {
+      const custom = new ClaudeAdapter({ apiKey: 'test', model: 'claude-opus-4-20250514' });
+      expect(custom.modelName).toBe('claude-opus-4-20250514');
+    });
+  });
+
+  // ─── Response Parsing ───
+
+  describe('response parsing', () => {
+    it('should parse text-only response', async () => {
+      mockCreate.mockResolvedValueOnce(makeAnthropicResponse({
+        content: [{ type: 'text', text: 'The merchant sells electronics.' }],
+        stop_reason: 'end_turn',
+      }));
+
+      const result = await adapter.chat([{ role: 'user', content: 'Hi' }]);
+
+      expect(result.content).toBe('The merchant sells electronics.');
+      expect(result.toolCalls).toHaveLength(0);
+      expect(result.finishReason).toBe('stop');
+    });
+
+    it('should parse tool_use response', async () => {
+      mockCreate.mockResolvedValueOnce(makeAnthropicResponse({
+        content: [
+          { type: 'text', text: 'Let me discover that merchant.' },
+          {
+            type: 'tool_use',
+            id: 'toolu_01ABC',
+            name: 'discover_merchant',
+            input: { domain: 'shop.example.com' },
+          },
+        ],
+        stop_reason: 'tool_use',
+      }));
+
+      const result = await adapter.chat([{ role: 'user', content: 'Discover shop.example.com' }]);
+
+      expect(result.content).toBe('Let me discover that merchant.');
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0]).toEqual({
+        id: 'toolu_01ABC',
+        name: 'discover_merchant',
+        arguments: { domain: 'shop.example.com' },
+      });
+      expect(result.finishReason).toBe('tool_calls');
+    });
+
+    it('should parse multiple tool calls', async () => {
+      mockCreate.mockResolvedValueOnce(makeAnthropicResponse({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_01',
+            name: 'search_products',
+            input: { query: 'headphones' },
+          },
+          {
+            type: 'tool_use',
+            id: 'toolu_02',
+            name: 'browse_products',
+            input: { limit: 5 },
+          },
+        ],
+        stop_reason: 'tool_use',
+      }));
+
+      const result = await adapter.chat([{ role: 'user', content: 'Find headphones' }]);
+
+      expect(result.toolCalls).toHaveLength(2);
+      expect(result.toolCalls[0].name).toBe('search_products');
+      expect(result.toolCalls[1].name).toBe('browse_products');
+    });
+
+    it('should map max_tokens stop reason to length', async () => {
+      mockCreate.mockResolvedValueOnce(makeAnthropicResponse({
+        stop_reason: 'max_tokens',
+      }));
+
+      const result = await adapter.chat([{ role: 'user', content: 'Hi' }]);
+      expect(result.finishReason).toBe('length');
+    });
+
+    it('should map usage tokens correctly', async () => {
+      mockCreate.mockResolvedValueOnce(makeAnthropicResponse({
+        usage: { input_tokens: 100, output_tokens: 50 },
+      }));
+
+      const result = await adapter.chat([{ role: 'user', content: 'Hi' }]);
+
+      expect(result.usage).toEqual({
+        promptTokens: 100,
+        completionTokens: 50,
+        totalTokens: 150,
+      });
+    });
+  });
+
+  // ─── Message Conversion ───
+
+  describe('message conversion', () => {
+    it('should skip system messages', async () => {
+      mockCreate.mockResolvedValueOnce(makeAnthropicResponse({}));
+
+      await adapter.chat([
+        { role: 'system', content: 'You are helpful.' },
+        { role: 'user', content: 'Hello' },
+      ]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      // System message goes to system param, not messages
+      expect(callArgs.messages).toHaveLength(1);
+      expect(callArgs.messages[0].role).toBe('user');
+    });
+
+    it('should pass system prompt as top-level parameter', async () => {
+      mockCreate.mockResolvedValueOnce(makeAnthropicResponse({}));
+
+      await adapter.chat([{ role: 'user', content: 'Hello' }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.system).toBeDefined();
+      expect(callArgs.system).toContain('UCP Shopping Agent');
+    });
+
+    it('should convert assistant messages with tool calls', async () => {
+      mockCreate.mockResolvedValueOnce(makeAnthropicResponse({}));
+
+      const messages: ChatMessage[] = [
+        { role: 'user', content: 'Discover example.com' },
+        {
+          role: 'assistant',
+          content: 'Let me discover that.',
+          toolCalls: [{
+            id: 'toolu_01ABC',
+            name: 'discover_merchant',
+            arguments: { domain: 'example.com' },
+          }],
+        },
+        {
+          role: 'tool',
+          content: '{"domain":"example.com"}',
+          toolCallId: 'discover_merchant',
+        },
+        { role: 'user', content: 'What did you find?' },
+      ];
+
+      await adapter.chat(messages);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      // Should be: user, assistant (with tool_use), user (with tool_result), user
+      expect(callArgs.messages).toHaveLength(4);
+
+      // Assistant message should have text + tool_use blocks
+      const assistantMsg = callArgs.messages[1];
+      expect(assistantMsg.role).toBe('assistant');
+      expect(assistantMsg.content).toHaveLength(2);
+      expect(assistantMsg.content[0]).toEqual({ type: 'text', text: 'Let me discover that.' });
+      expect(assistantMsg.content[1]).toMatchObject({
+        type: 'tool_use',
+        id: 'toolu_01ABC',
+        name: 'discover_merchant',
+      });
+
+      // Tool result should use the actual ID, not the tool name
+      const toolResultMsg = callArgs.messages[2];
+      expect(toolResultMsg.role).toBe('user');
+      expect(toolResultMsg.content[0]).toMatchObject({
+        type: 'tool_result',
+        tool_use_id: 'toolu_01ABC',
+      });
+    });
+
+    it('should resolve name-based toolCallId to actual tool_use_id', async () => {
+      mockCreate.mockResolvedValueOnce(makeAnthropicResponse({}));
+
+      const messages: ChatMessage[] = [
+        { role: 'user', content: 'Search' },
+        {
+          role: 'assistant',
+          content: '',
+          toolCalls: [{
+            id: 'toolu_REAL_ID',
+            name: 'search_products',
+            arguments: { query: 'test' },
+          }],
+        },
+        {
+          role: 'tool',
+          content: '{"products":[]}',
+          toolCallId: 'search_products', // Name, not ID — this is what ShoppingAgent does
+        },
+      ];
+
+      await adapter.chat(messages);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      const toolResultMsg = callArgs.messages[2];
+      expect(toolResultMsg.content[0].tool_use_id).toBe('toolu_REAL_ID');
+    });
+
+    it('should merge consecutive tool results into one user message', async () => {
+      mockCreate.mockResolvedValueOnce(makeAnthropicResponse({}));
+
+      const messages: ChatMessage[] = [
+        { role: 'user', content: 'Do stuff' },
+        {
+          role: 'assistant',
+          content: '',
+          toolCalls: [
+            { id: 'toolu_01', name: 'search_products', arguments: { query: 'a' } },
+            { id: 'toolu_02', name: 'browse_products', arguments: { limit: 5 } },
+          ],
+        },
+        { role: 'tool', content: '{"result":"a"}', toolCallId: 'search_products' },
+        { role: 'tool', content: '{"result":"b"}', toolCallId: 'browse_products' },
+      ];
+
+      await adapter.chat(messages);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      // user, assistant, user (merged tool results)
+      expect(callArgs.messages).toHaveLength(3);
+
+      const mergedMsg = callArgs.messages[2];
+      expect(mergedMsg.role).toBe('user');
+      expect(mergedMsg.content).toHaveLength(2);
+      expect(mergedMsg.content[0].tool_use_id).toBe('toolu_01');
+      expect(mergedMsg.content[1].tool_use_id).toBe('toolu_02');
+    });
+
+    it('should handle same tool called twice with correct ID resolution', async () => {
+      mockCreate.mockResolvedValueOnce(makeAnthropicResponse({}));
+
+      const messages: ChatMessage[] = [
+        { role: 'user', content: 'Add two items' },
+        {
+          role: 'assistant',
+          content: '',
+          toolCalls: [
+            { id: 'toolu_FIRST', name: 'add_to_cart', arguments: { productId: 'a' } },
+            { id: 'toolu_SECOND', name: 'add_to_cart', arguments: { productId: 'b' } },
+          ],
+        },
+        { role: 'tool', content: '{"ok":true}', toolCallId: 'add_to_cart' },
+        { role: 'tool', content: '{"ok":true}', toolCallId: 'add_to_cart' },
+      ];
+
+      await adapter.chat(messages);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      const mergedMsg = callArgs.messages[2];
+      // First add_to_cart result should get FIRST id, second should get SECOND id
+      expect(mergedMsg.content[0].tool_use_id).toBe('toolu_FIRST');
+      expect(mergedMsg.content[1].tool_use_id).toBe('toolu_SECOND');
+    });
+  });
+
+  // ─── Tool Definition Conversion ───
+
+  describe('tool definition conversion', () => {
+    it('should convert ToolDefinition to Anthropic Tool format', async () => {
+      mockCreate.mockResolvedValueOnce(makeAnthropicResponse({}));
+
+      const tools: ToolDefinition[] = [{
+        name: 'discover_merchant',
+        description: 'Discover a UCP merchant by domain',
+        parameters: {
+          type: 'object',
+          properties: {
+            domain: { type: 'string', description: 'Merchant domain' },
+          },
+          required: ['domain'],
+        },
+      }];
+
+      await adapter.chat([{ role: 'user', content: 'Hi' }], tools);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.tools).toHaveLength(1);
+      expect(callArgs.tools[0]).toEqual({
+        name: 'discover_merchant',
+        description: 'Discover a UCP merchant by domain',
+        input_schema: {
+          type: 'object',
+          properties: {
+            domain: { type: 'string', description: 'Merchant domain' },
+          },
+          required: ['domain'],
+        },
+      });
+    });
+
+    it('should not pass tools when none provided', async () => {
+      mockCreate.mockResolvedValueOnce(makeAnthropicResponse({}));
+
+      await adapter.chat([{ role: 'user', content: 'Hi' }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.tools).toBeUndefined();
+    });
+  });
+
+  // ─── API Call Parameters ───
+
+  describe('API call parameters', () => {
+    it('should pass default parameters', async () => {
+      mockCreate.mockResolvedValueOnce(makeAnthropicResponse({}));
+
+      await adapter.chat([{ role: 'user', content: 'Hi' }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.model).toBe('claude-sonnet-4-20250514');
+      expect(callArgs.max_tokens).toBe(4096);
+      expect(callArgs.temperature).toBe(0.7);
+    });
+
+    it('should use custom options', async () => {
+      const custom = new ClaudeAdapter({
+        apiKey: 'test',
+        model: 'claude-haiku-4-20250414',
+        maxTokens: 1024,
+        temperature: 0.3,
+      });
+
+      mockCreate.mockResolvedValueOnce(makeAnthropicResponse({}));
+      await custom.chat([{ role: 'user', content: 'Hi' }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.model).toBe('claude-haiku-4-20250414');
+      expect(callArgs.max_tokens).toBe(1024);
+      expect(callArgs.temperature).toBe(0.3);
+    });
+
+    it('should use custom system prompt', async () => {
+      const custom = new ClaudeAdapter({
+        apiKey: 'test',
+        systemPrompt: 'You are a test bot.',
+      });
+
+      mockCreate.mockResolvedValueOnce(makeAnthropicResponse({}));
+      await custom.chat([{ role: 'user', content: 'Hi' }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.system).toBe('You are a test bot.');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implement `ClaudeAdapter` for the `LlmAdapter` interface, enabling `ShoppingAgent` to use Anthropic Claude models with full tool use support
- Add `@anthropic-ai/sdk` dependency
- Export `ClaudeAdapter` and `ClaudeAdapterOptions` from the public API
- 18 new tests (55 total, all passing)

## Key design decisions

- **toolCallId resolution**: `ShoppingAgent` sets `toolCallId` to the tool name, but Anthropic requires the actual `tool_use_id`. The adapter maintains a name→ID queue to resolve this transparently.
- **Role alternation**: Consecutive tool results are merged into a single `user` message with multiple `tool_result` blocks (Anthropic requirement).
- **JSON Schema passthrough**: Unlike Gemini (which needs `SchemaType` enum conversion), Anthropic accepts JSON Schema directly in `input_schema`, making the tool conversion simpler.
- **Default model**: `claude-sonnet-4-20250514` — good balance of capability and cost for agentic tool use.

## Test plan

- [x] 18 new unit tests covering constructor, message conversion, toolCallId resolution, tool definition conversion, response parsing, and API parameters
- [x] `npm run typecheck` — clean
- [x] `npm test` — 55 tests passing (37 existing + 18 new)
- [x] `npm run build` — clean

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)