### PR TITLE
feat: Add ACP client and dual-protocol support

### DIFF
--- a/src/client/acp-client.ts
+++ b/src/client/acp-client.ts
@@ -1,0 +1,156 @@
+/**
+ * ACP Client - Interaction with ACP-enabled merchants
+ *
+ * Implements the Agentic Commerce Protocol (OpenAI/Stripe) checkout session
+ * lifecycle: create, get, update, complete, cancel.
+ *
+ * ACP spec: https://github.com/agentic-commerce-protocol/agentic-commerce-protocol
+ */
+
+import type {
+  AcpClientOptions,
+  AcpCheckoutSession,
+  AcpShippingAddress,
+} from '../types/index.js';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_API_VERSION = '2026-01-30';
+
+export class AcpClient {
+  private readonly endpoint: string;
+  private readonly apiKey: string;
+  private readonly apiVersion: string;
+  private readonly timeoutMs: number;
+  private readonly fetchFn: typeof globalThis.fetch;
+
+  constructor(options: AcpClientOptions) {
+    this.endpoint = options.endpoint.replace(/\/+$/, '');
+    this.apiKey = options.apiKey;
+    this.apiVersion = options.apiVersion ?? DEFAULT_API_VERSION;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.fetchFn = options.fetch ?? globalThis.fetch.bind(globalThis);
+  }
+
+  /**
+   * Create a new checkout session.
+   * POST /checkout_sessions
+   */
+  async createCheckout(params: {
+    line_items: Array<{
+      product_id: string;
+      quantity: number;
+      variant_id?: string;
+    }>;
+    shipping_address?: AcpShippingAddress;
+  }): Promise<AcpCheckoutSession> {
+    return this.request('POST', '/checkout_sessions', params);
+  }
+
+  /**
+   * Get an existing checkout session.
+   * GET /checkout_sessions/:id
+   */
+  async getCheckout(sessionId: string): Promise<AcpCheckoutSession> {
+    return this.request('GET', `/checkout_sessions/${sessionId}`);
+  }
+
+  /**
+   * Update a checkout session (e.g., add shipping address, select payment handler).
+   * POST /checkout_sessions/:id
+   */
+  async updateCheckout(
+    sessionId: string,
+    params: {
+      shipping_address?: AcpShippingAddress;
+      payment_handler?: string;
+      discount_code?: string;
+    }
+  ): Promise<AcpCheckoutSession> {
+    return this.request('POST', `/checkout_sessions/${sessionId}`, params);
+  }
+
+  /**
+   * Complete a checkout session with payment.
+   * POST /checkout_sessions/:id/complete
+   */
+  async completeCheckout(
+    sessionId: string,
+    params: {
+      payment_token: string;
+      payment_handler: string;
+    }
+  ): Promise<AcpCheckoutSession> {
+    return this.request(
+      'POST',
+      `/checkout_sessions/${sessionId}/complete`,
+      params
+    );
+  }
+
+  /**
+   * Cancel a checkout session.
+   * POST /checkout_sessions/:id/cancel
+   */
+  async cancelCheckout(sessionId: string): Promise<AcpCheckoutSession> {
+    return this.request('POST', `/checkout_sessions/${sessionId}/cancel`);
+  }
+
+  /**
+   * Get the configured endpoint URL.
+   */
+  getEndpoint(): string {
+    return this.endpoint;
+  }
+
+  // ─── Internal ───
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown
+  ): Promise<T> {
+    const url = `${this.endpoint}${path}`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await this.fetchFn(url, {
+        method,
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+          'API-Version': this.apiVersion,
+          'Request-Id': `req_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        },
+        ...(body ? { body: JSON.stringify(body) } : {}),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text().catch(() => '');
+        throw new AcpApiError(
+          `ACP API call failed: ${method} ${path} → ${response.status}`,
+          response.status,
+          errorBody
+        );
+      }
+
+      return (await response.json()) as T;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+// ─── Error classes ───
+
+export class AcpApiError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+    public readonly responseBody: string
+  ) {
+    super(message);
+    this.name = 'AcpApiError';
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,8 +29,9 @@
  * ```
  */
 
-// Core client
+// Core clients
 export { UcpClient, UcpDiscoveryError, UcpApiError } from './client/ucp-client.js';
+export { AcpClient, AcpApiError } from './client/acp-client.js';
 
 // LLM adapters
 export { GeminiAdapter } from './llm/gemini.js';
@@ -46,8 +47,9 @@ export { ShoppingAgent } from './agent/shopping-agent.js';
 // Tools
 export { SHOPPING_AGENT_TOOLS } from './llm/tools.js';
 
-// Mock server
+// Mock servers
 export { MockMerchant } from './mock/mock-merchant.js';
+export { MockAcpMerchant } from './mock/mock-acp-merchant.js';
 export { DEFAULT_PRODUCTS, buildMockProfile } from './mock/fixtures.js';
 
 // Types
@@ -61,6 +63,15 @@ export type {
   A2aTransport,
   PaymentHandler,
   JwkKey,
+
+  // ACP types
+  AcpClientOptions,
+  AcpCheckoutSession,
+  AcpCheckoutStatus,
+  AcpLineItem,
+  AcpMoney,
+  AcpShippingAddress,
+  MockAcpMerchantOptions,
 
   // Client types
   UcpClientOptions,

--- a/src/mock/mock-acp-merchant.ts
+++ b/src/mock/mock-acp-merchant.ts
@@ -1,0 +1,332 @@
+/**
+ * Mock ACP Merchant Server
+ *
+ * A mock merchant implementing the Agentic Commerce Protocol (ACP) for testing.
+ * Serves ACP checkout session endpoints and product browsing endpoints.
+ *
+ * ACP endpoints:
+ *   POST   /checkout_sessions              - Create checkout
+ *   GET    /checkout_sessions/:id          - Get session
+ *   POST   /checkout_sessions/:id          - Update session
+ *   POST   /checkout_sessions/:id/complete - Complete with payment
+ *   POST   /checkout_sessions/:id/cancel   - Cancel session
+ *
+ * Product endpoints (for agent browsing):
+ *   GET    /products                       - List products
+ *   GET    /products/search?q=...          - Search products
+ *   GET    /products/:id                   - Get product
+ */
+
+import type { Server } from 'node:http';
+import type {
+  MockAcpMerchantOptions,
+  MockProduct,
+  AcpCheckoutSession,
+  AcpCheckoutStatus,
+  AcpLineItem,
+  AcpMoney,
+  AcpShippingAddress,
+} from '../types/index.js';
+import { DEFAULT_PRODUCTS } from './fixtures.js';
+
+interface AcpSessionState {
+  session: AcpCheckoutSession;
+  productIds: string[];
+}
+
+export class MockAcpMerchant {
+  private server: Server | null = null;
+  private port: number;
+  private readonly name: string;
+  private readonly products: MockProduct[];
+  private readonly apiKey: string;
+
+  // Server-side state
+  private sessions: Map<string, AcpSessionState> = new Map();
+
+  constructor(options: MockAcpMerchantOptions = {}) {
+    this.port = options.port ?? 0;
+    this.name = options.name ?? 'Mock ACP Merchant';
+    this.products = options.products ?? DEFAULT_PRODUCTS;
+    this.apiKey = options.apiKey ?? 'test_acp_key';
+  }
+
+  async start(): Promise<void> {
+    const { default: express } = await import('express');
+    const app = express();
+    app.use(express.json());
+
+    // ─── Bearer Token Auth (for ACP endpoints) ───
+    const authMiddleware = (
+      req: import('express').Request,
+      res: import('express').Response,
+      next: import('express').NextFunction
+    ) => {
+      const auth = req.headers.authorization;
+      if (!auth || !auth.startsWith('Bearer ') || auth.slice(7) !== this.apiKey) {
+        res.status(401).json({ error: 'Unauthorized: invalid or missing Bearer token' });
+        return;
+      }
+      next();
+    };
+
+    // ─── Product API (no auth required — public catalog) ───
+
+    app.get('/products', (_req, res) => {
+      let filtered = [...this.products];
+      const category = _req.query.category as string | undefined;
+      if (category) {
+        filtered = filtered.filter(
+          p => p.category?.toLowerCase() === category.toLowerCase()
+        );
+      }
+      res.json({ products: filtered, total: filtered.length });
+    });
+
+    app.get('/products/search', (req, res) => {
+      const q = ((req.query.q as string) ?? '').toLowerCase();
+      const filtered = this.products.filter(
+        p =>
+          p.name.toLowerCase().includes(q) ||
+          p.description.toLowerCase().includes(q) ||
+          (p.category?.toLowerCase().includes(q) ?? false)
+      );
+      res.json({ products: filtered, total: filtered.length, query: q });
+    });
+
+    app.get('/products/:id', (req, res) => {
+      const product = this.products.find(p => p.id === req.params.id);
+      if (!product) {
+        res.status(404).json({ error: `Product not found: ${req.params.id}` });
+        return;
+      }
+      res.json(product);
+    });
+
+    // ─── ACP Checkout Endpoints (auth required) ───
+
+    // POST /checkout_sessions — Create
+    app.post('/checkout_sessions', authMiddleware, (req, res) => {
+      const lineItemRequests = req.body.line_items as Array<{
+        product_id: string;
+        quantity: number;
+        variant_id?: string;
+      }> | undefined;
+
+      if (!lineItemRequests || lineItemRequests.length === 0) {
+        res.status(400).json({ error: 'line_items is required and must not be empty' });
+        return;
+      }
+
+      const lineItems: AcpLineItem[] = [];
+      const productIds: string[] = [];
+
+      for (const item of lineItemRequests) {
+        const product = this.products.find(p => p.id === item.product_id);
+        if (!product) {
+          res.status(400).json({ error: `Product not found: ${item.product_id}` });
+          return;
+        }
+
+        const unitPriceCents = this.dollarsToCents(product.price.amount);
+        lineItems.push({
+          id: `li_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+          name: product.name,
+          quantity: item.quantity,
+          unit_price: { amount: unitPriceCents, currency: product.price.currency },
+          total_price: { amount: unitPriceCents * item.quantity, currency: product.price.currency },
+        });
+        productIds.push(product.id);
+      }
+
+      const subtotal = lineItems.reduce((sum, li) => sum + li.total_price.amount, 0);
+      const currency = lineItems[0].unit_price.currency;
+
+      const sessionId = `cs_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      const status: AcpCheckoutStatus = req.body.shipping_address
+        ? 'ready_for_payment'
+        : 'not_ready_for_payment';
+
+      const session: AcpCheckoutSession = {
+        id: sessionId,
+        status,
+        line_items: lineItems,
+        totals: {
+          subtotal: { amount: subtotal, currency },
+          total: { amount: subtotal, currency },
+        },
+        payment_handlers: [
+          {
+            type: 'stripe_shared_payment_token',
+            handler_spec: {
+              version: '2026-01-30',
+              supported_currencies: ['usd', 'eur', 'gbp'],
+            },
+          },
+        ],
+        links: {
+          terms_of_use: `${this.baseUrl}/terms`,
+          privacy_policy: `${this.baseUrl}/privacy`,
+          return_policy: `${this.baseUrl}/returns`,
+        },
+        ...(req.body.shipping_address ? { shipping_address: req.body.shipping_address } : {}),
+      };
+
+      this.sessions.set(sessionId, { session, productIds });
+      res.status(201).json(session);
+    });
+
+    // GET /checkout_sessions/:id — Get
+    app.get('/checkout_sessions/:id', authMiddleware, (req, res) => {
+      const state = this.sessions.get(req.params.id as string);
+      if (!state) {
+        res.status(404).json({ error: `Checkout session not found: ${req.params.id}` });
+        return;
+      }
+      res.json(state.session);
+    });
+
+    // POST /checkout_sessions/:id — Update
+    app.post('/checkout_sessions/:id', authMiddleware, (req, res) => {
+      // Avoid matching /complete and /cancel routes
+      if (req.params.id.includes('/')) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+      }
+
+      const state = this.sessions.get(req.params.id as string);
+      if (!state) {
+        res.status(404).json({ error: `Checkout session not found: ${req.params.id}` });
+        return;
+      }
+
+      if (state.session.status === 'completed' || state.session.status === 'canceled') {
+        res.status(400).json({ error: `Cannot update session in ${state.session.status} state` });
+        return;
+      }
+
+      if (req.body.shipping_address) {
+        state.session.shipping_address = req.body.shipping_address as AcpShippingAddress;
+        // Add shipping cost
+        const shippingCost: AcpMoney = { amount: 599, currency: state.session.totals.subtotal.currency };
+        state.session.totals.shipping = shippingCost;
+        state.session.totals.total = {
+          amount: state.session.totals.subtotal.amount + shippingCost.amount + (state.session.totals.tax?.amount ?? 0),
+          currency: state.session.totals.subtotal.currency,
+        };
+        state.session.status = 'ready_for_payment';
+      }
+
+      res.json(state.session);
+    });
+
+    // POST /checkout_sessions/:id/complete — Complete
+    app.post('/checkout_sessions/:id/complete', authMiddleware, (req, res) => {
+      const state = this.sessions.get(req.params.id as string);
+      if (!state) {
+        res.status(404).json({ error: `Checkout session not found: ${req.params.id}` });
+        return;
+      }
+
+      if (state.session.status !== 'ready_for_payment') {
+        res.status(400).json({
+          error: `Cannot complete session in ${state.session.status} state. Must be ready_for_payment.`,
+        });
+        return;
+      }
+
+      const { payment_token, payment_handler } = req.body;
+      if (!payment_token || !payment_handler) {
+        res.status(400).json({ error: 'payment_token and payment_handler are required' });
+        return;
+      }
+
+      // Simulate payment failure
+      if (payment_token === 'tok_mock_failure') {
+        state.session.status = 'not_ready_for_payment';
+        res.status(402).json({ error: 'Payment declined', session: state.session });
+        return;
+      }
+
+      state.session.status = 'completed';
+      res.json(state.session);
+    });
+
+    // POST /checkout_sessions/:id/cancel — Cancel
+    app.post('/checkout_sessions/:id/cancel', authMiddleware, (req, res) => {
+      const state = this.sessions.get(req.params.id as string);
+      if (!state) {
+        res.status(404).json({ error: `Checkout session not found: ${req.params.id}` });
+        return;
+      }
+
+      if (state.session.status === 'completed') {
+        res.status(400).json({ error: 'Cannot cancel a completed session' });
+        return;
+      }
+
+      state.session.status = 'canceled';
+      res.json(state.session);
+    });
+
+    // ─── Health Check ───
+    app.get('/health', (_req, res) => {
+      res.json({ status: 'ok', merchant: this.name, protocol: 'acp' });
+    });
+
+    // Start listening
+    return new Promise<void>((resolve) => {
+      this.server = app.listen(this.port, () => {
+        const addr = this.server!.address();
+        if (typeof addr === 'object' && addr) {
+          this.port = addr.port;
+        }
+        resolve();
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (!this.server) {
+        resolve();
+        return;
+      }
+      this.server.close((err) => {
+        this.server = null;
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  }
+
+  get baseUrl(): string {
+    return `http://localhost:${this.port}`;
+  }
+
+  get domain(): string {
+    return `localhost:${this.port}`;
+  }
+
+  get acpEndpoint(): string {
+    return this.baseUrl;
+  }
+
+  get requiredApiKey(): string {
+    return this.apiKey;
+  }
+
+  getSessions(): AcpCheckoutSession[] {
+    return [...this.sessions.values()].map(s => s.session);
+  }
+
+  reset(): void {
+    this.sessions.clear();
+  }
+
+  // ─── Helpers ───
+
+  private dollarsToCents(dollarString: string): number {
+    return Math.round(parseFloat(dollarString) * 100);
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -78,6 +78,88 @@ export interface UcpProfile {
   [key: string]: unknown;
 }
 
+// ─── ACP Types (Agentic Commerce Protocol — OpenAI/Stripe) ───
+
+export interface AcpClientOptions {
+  /** ACP merchant endpoint URL */
+  endpoint: string;
+  /** Bearer token for authentication */
+  apiKey: string;
+  /** API version (default: 2026-01-30) */
+  apiVersion?: string;
+  /** Request timeout in ms (default: 30000) */
+  timeoutMs?: number;
+  /** Custom fetch implementation for testing */
+  fetch?: typeof globalThis.fetch;
+}
+
+export type AcpCheckoutStatus =
+  | 'not_ready_for_payment'
+  | 'ready_for_payment'
+  | 'in_progress'
+  | 'authentication_required'
+  | 'completed'
+  | 'canceled';
+
+export interface AcpMoney {
+  /** Amount in minor units (cents). e.g. $29.99 = 2999 */
+  amount: number;
+  /** ISO 4217 currency code */
+  currency: string;
+}
+
+export interface AcpLineItem {
+  id: string;
+  name: string;
+  quantity: number;
+  unit_price: AcpMoney;
+  total_price: AcpMoney;
+  image_url?: string;
+}
+
+export interface AcpShippingAddress {
+  name: string;
+  line1: string;
+  line2?: string;
+  city: string;
+  state: string;
+  postal_code: string;
+  country: string;
+}
+
+export interface AcpCheckoutSession {
+  id: string;
+  status: AcpCheckoutStatus;
+  line_items: AcpLineItem[];
+  totals: {
+    subtotal: AcpMoney;
+    tax?: AcpMoney;
+    shipping?: AcpMoney;
+    total: AcpMoney;
+  };
+  payment_handlers?: Array<{
+    type: string;
+    handler_spec: Record<string, unknown>;
+  }>;
+  links?: {
+    terms_of_use?: string;
+    privacy_policy?: string;
+    return_policy?: string;
+  };
+  shipping_address?: AcpShippingAddress;
+}
+
+export interface MockAcpMerchantOptions {
+  /** Port to listen on (default: 0 for random) */
+  port?: number;
+  /** Merchant name */
+  name?: string;
+  /** Product catalog */
+  products?: MockProduct[];
+  /** Required API key for authentication */
+  apiKey?: string;
+}
+
 // ─── SDK Client Types ───
 
 export interface UcpClientOptions {
@@ -165,6 +247,8 @@ export interface AgentOptions {
   llm: LlmAdapter;
   /** UCP client options */
   clientOptions?: UcpClientOptions;
+  /** ACP client options (enables ACP protocol support) */
+  acpOptions?: AcpClientOptions;
   /** Maximum agent loop iterations (default: 20) */
   maxIterations?: number;
   /** Enable verbose logging */

--- a/tests/acp-agent.test.ts
+++ b/tests/acp-agent.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Tests for ShoppingAgent with ACP protocol support
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ShoppingAgent } from '../src/agent/shopping-agent.js';
+import { MockAcpMerchant } from '../src/mock/mock-acp-merchant.js';
+import { MockMerchant } from '../src/mock/mock-merchant.js';
+import type { LlmAdapter, ChatMessage, ToolDefinition, LlmResponse, ToolCall } from '../src/types/index.js';
+
+class ScriptedLlm implements LlmAdapter {
+  readonly modelName = 'scripted-mock';
+  private callIndex = 0;
+  private readonly script: Array<{
+    content?: string;
+    toolCalls?: ToolCall[];
+  }>;
+
+  constructor(script: Array<{ content?: string; toolCalls?: ToolCall[] }>) {
+    this.script = script;
+  }
+
+  async chat(_messages: ChatMessage[], _tools?: ToolDefinition[]): Promise<LlmResponse> {
+    const step = this.script[this.callIndex++];
+    if (!step) {
+      return { content: 'Done.', toolCalls: [], finishReason: 'stop' };
+    }
+    return {
+      content: step.content ?? '',
+      toolCalls: step.toolCalls ?? [],
+      finishReason: step.toolCalls?.length ? 'tool_calls' : 'stop',
+    };
+  }
+}
+
+describe('ShoppingAgent with ACP', () => {
+  let acpMerchant: MockAcpMerchant;
+
+  beforeAll(async () => {
+    acpMerchant = new MockAcpMerchant({ name: 'ACP Agent Test Store' });
+    await acpMerchant.start();
+  });
+
+  afterAll(async () => {
+    await acpMerchant.stop();
+  });
+
+  it('should discover an ACP merchant when UCP fails', async () => {
+    const llm = new ScriptedLlm([
+      {
+        content: 'Discovering merchant...',
+        toolCalls: [{
+          id: 'call_1',
+          name: 'discover_merchant',
+          arguments: { domain: acpMerchant.domain },
+        }],
+      },
+      {
+        content: `Found ACP merchant at ${acpMerchant.domain} with checkout capability.`,
+      },
+    ]);
+
+    const agent = new ShoppingAgent({
+      llm,
+      acpOptions: {
+        endpoint: acpMerchant.acpEndpoint,
+        apiKey: acpMerchant.requiredApiKey,
+      },
+    });
+
+    const result = await agent.run(`Discover ${acpMerchant.domain}`);
+    expect(result.success).toBe(true);
+
+    // Verify discovery returned ACP info
+    const discoverStep = result.steps.find(
+      s => s.type === 'tool_result' && s.toolName === 'discover_merchant'
+    );
+    expect(discoverStep).toBeDefined();
+    const output = discoverStep!.toolOutput as Record<string, unknown>;
+    expect(output.protocol).toBe('acp');
+  });
+
+  it('should browse products on ACP merchant', async () => {
+    const llm = new ScriptedLlm([
+      {
+        toolCalls: [{
+          id: 'call_1',
+          name: 'discover_merchant',
+          arguments: { domain: acpMerchant.domain },
+        }],
+      },
+      {
+        toolCalls: [{
+          id: 'call_2',
+          name: 'browse_products',
+          arguments: { limit: 5 },
+        }],
+      },
+      {
+        content: 'Found products on the ACP merchant.',
+      },
+    ]);
+
+    const agent = new ShoppingAgent({
+      llm,
+      acpOptions: {
+        endpoint: acpMerchant.acpEndpoint,
+        apiKey: acpMerchant.requiredApiKey,
+      },
+    });
+
+    const result = await agent.run('Browse products');
+    expect(result.success).toBe(true);
+
+    const browseStep = result.steps.find(
+      s => s.type === 'tool_result' && s.toolName === 'browse_products'
+    );
+    const output = browseStep!.toolOutput as Record<string, unknown>;
+    expect((output.products as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it('should search products on ACP merchant', async () => {
+    const llm = new ScriptedLlm([
+      {
+        toolCalls: [{
+          id: 'call_1',
+          name: 'discover_merchant',
+          arguments: { domain: acpMerchant.domain },
+        }],
+      },
+      {
+        toolCalls: [{
+          id: 'call_2',
+          name: 'search_products',
+          arguments: { query: 'keyboard' },
+        }],
+      },
+      { content: 'Found keyboards.' },
+    ]);
+
+    const agent = new ShoppingAgent({
+      llm,
+      acpOptions: {
+        endpoint: acpMerchant.acpEndpoint,
+        apiKey: acpMerchant.requiredApiKey,
+      },
+    });
+
+    const result = await agent.run('Search for keyboards');
+    expect(result.success).toBe(true);
+  });
+
+  it('should complete a full ACP checkout flow', async () => {
+    const llm = new ScriptedLlm([
+      // 1. Discover
+      {
+        toolCalls: [{
+          id: 'call_1',
+          name: 'discover_merchant',
+          arguments: { domain: acpMerchant.domain },
+        }],
+      },
+      // 2. Add to cart
+      {
+        toolCalls: [{
+          id: 'call_2',
+          name: 'add_to_cart',
+          arguments: { productId: 'prod_laptop_stand', quantity: 1 },
+        }],
+      },
+      // 3. Initiate checkout (ACP: creates checkout session)
+      {
+        toolCalls: [{
+          id: 'call_3',
+          name: 'initiate_checkout',
+          arguments: {},
+        }],
+      },
+      // 4. Submit shipping (ACP: updates checkout session)
+      {
+        toolCalls: [{
+          id: 'call_4',
+          name: 'submit_shipping',
+          arguments: {
+            name: 'Test User',
+            line1: '123 Main St',
+            city: 'San Francisco',
+            state: 'CA',
+            postalCode: '94105',
+            country: 'US',
+          },
+        }],
+      },
+      // 5. Submit payment (ACP: completes checkout session)
+      {
+        toolCalls: [{
+          id: 'call_5',
+          name: 'submit_payment',
+          arguments: {
+            paymentMethod: 'stripe_shared_payment_token',
+            paymentToken: 'tok_mock_success',
+          },
+        }],
+      },
+      // 6. Final answer
+      { content: 'Order placed via ACP!' },
+    ]);
+
+    const agent = new ShoppingAgent({
+      llm,
+      acpOptions: {
+        endpoint: acpMerchant.acpEndpoint,
+        apiKey: acpMerchant.requiredApiKey,
+      },
+    });
+
+    const result = await agent.run(
+      `Buy a laptop stand from ${acpMerchant.domain}`
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.checkout).toBeDefined();
+    expect(result.checkout!.orderId).toMatch(/^acp_cs_/);
+    expect(result.checkout!.status).toBe('completed');
+    expect(result.iterations).toBe(6);
+  });
+
+  it('should list ACP capabilities', async () => {
+    const llm = new ScriptedLlm([
+      {
+        toolCalls: [{
+          id: 'call_1',
+          name: 'discover_merchant',
+          arguments: { domain: acpMerchant.domain },
+        }],
+      },
+      {
+        toolCalls: [{
+          id: 'call_2',
+          name: 'list_capabilities',
+          arguments: {},
+        }],
+      },
+      { content: 'ACP merchant supports checkout.' },
+    ]);
+
+    const agent = new ShoppingAgent({
+      llm,
+      acpOptions: {
+        endpoint: acpMerchant.acpEndpoint,
+        apiKey: acpMerchant.requiredApiKey,
+      },
+    });
+
+    const result = await agent.run('List capabilities');
+    expect(result.success).toBe(true);
+
+    const capStep = result.steps.find(
+      s => s.type === 'tool_result' && s.toolName === 'list_capabilities'
+    );
+    const output = capStep!.toolOutput as Record<string, unknown>;
+    const caps = output.capabilities as Array<{ name: string }>;
+    expect(caps.some(c => c.name === 'acp.checkout')).toBe(true);
+  });
+});
+
+describe('Protocol detection (UCP vs ACP)', () => {
+  let ucpMerchant: MockMerchant;
+  let acpMerchant: MockAcpMerchant;
+
+  beforeAll(async () => {
+    ucpMerchant = new MockMerchant({ name: 'UCP Store' });
+    acpMerchant = new MockAcpMerchant({ name: 'ACP Store' });
+    await ucpMerchant.start();
+    await acpMerchant.start();
+  });
+
+  afterAll(async () => {
+    await ucpMerchant.stop();
+    await acpMerchant.stop();
+  });
+
+  it('should prefer UCP when both are available', async () => {
+    const llm = new ScriptedLlm([
+      {
+        toolCalls: [{
+          id: 'call_1',
+          name: 'discover_merchant',
+          arguments: { domain: ucpMerchant.domain },
+        }],
+      },
+      { content: 'Found UCP merchant.' },
+    ]);
+
+    const agent = new ShoppingAgent({
+      llm,
+      acpOptions: {
+        endpoint: acpMerchant.acpEndpoint,
+        apiKey: acpMerchant.requiredApiKey,
+      },
+    });
+
+    const result = await agent.run('Discover UCP merchant');
+    const discoverStep = result.steps.find(
+      s => s.type === 'tool_result' && s.toolName === 'discover_merchant'
+    );
+    const output = discoverStep!.toolOutput as Record<string, unknown>;
+    expect(output.protocol).toBe('ucp');
+  });
+
+  it('should fall back to ACP when UCP is not available', async () => {
+    const llm = new ScriptedLlm([
+      {
+        toolCalls: [{
+          id: 'call_1',
+          name: 'discover_merchant',
+          // Use ACP merchant domain — has no /.well-known/ucp
+          arguments: { domain: acpMerchant.domain },
+        }],
+      },
+      { content: 'Found ACP merchant.' },
+    ]);
+
+    const agent = new ShoppingAgent({
+      llm,
+      acpOptions: {
+        endpoint: acpMerchant.acpEndpoint,
+        apiKey: acpMerchant.requiredApiKey,
+      },
+    });
+
+    const result = await agent.run('Discover ACP merchant');
+    const discoverStep = result.steps.find(
+      s => s.type === 'tool_result' && s.toolName === 'discover_merchant'
+    );
+    const output = discoverStep!.toolOutput as Record<string, unknown>;
+    expect(output.protocol).toBe('acp');
+  });
+
+  it('should return error when neither protocol works', async () => {
+    const llm = new ScriptedLlm([
+      {
+        toolCalls: [{
+          id: 'call_1',
+          name: 'discover_merchant',
+          arguments: { domain: 'localhost:1' },
+        }],
+      },
+      { content: 'Could not discover merchant.' },
+    ]);
+
+    const agent = new ShoppingAgent({
+      llm,
+      clientOptions: { timeoutMs: 1000 },
+    });
+
+    const result = await agent.run('Discover nonexistent');
+    const discoverStep = result.steps.find(
+      s => s.type === 'tool_result' && s.toolName === 'discover_merchant'
+    );
+    const output = discoverStep!.toolOutput as Record<string, unknown>;
+    expect(output.error).toBeDefined();
+  });
+});

--- a/tests/acp-client.test.ts
+++ b/tests/acp-client.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Tests for AcpClient and MockAcpMerchant
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { AcpClient, AcpApiError } from '../src/client/acp-client.js';
+import { MockAcpMerchant } from '../src/mock/mock-acp-merchant.js';
+
+describe('MockAcpMerchant', () => {
+  let merchant: MockAcpMerchant;
+
+  beforeAll(async () => {
+    merchant = new MockAcpMerchant({ name: 'ACP Test Store' });
+    await merchant.start();
+  });
+
+  afterAll(async () => {
+    await merchant.stop();
+  });
+
+  describe('server lifecycle', () => {
+    it('should start and assign a port', () => {
+      expect(merchant.baseUrl).toMatch(/^http:\/\/localhost:\d+$/);
+    });
+
+    it('should respond to health check', async () => {
+      const res = await fetch(`${merchant.baseUrl}/health`);
+      const data = await res.json();
+      expect(data.status).toBe('ok');
+      expect(data.protocol).toBe('acp');
+    });
+  });
+
+  describe('product API', () => {
+    it('should list all products', async () => {
+      const res = await fetch(`${merchant.baseUrl}/products`);
+      const data = await res.json();
+      expect(data.products.length).toBeGreaterThan(0);
+      expect(data.total).toBeGreaterThan(0);
+    });
+
+    it('should search products', async () => {
+      const res = await fetch(`${merchant.baseUrl}/products/search?q=headphones`);
+      const data = await res.json();
+      expect(data.products.length).toBeGreaterThan(0);
+    });
+
+    it('should get a product by ID', async () => {
+      const res = await fetch(`${merchant.baseUrl}/products/prod_webcam`);
+      const data = await res.json();
+      expect(data.id).toBe('prod_webcam');
+    });
+
+    it('should return 404 for unknown product', async () => {
+      const res = await fetch(`${merchant.baseUrl}/products/nonexistent`);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('ACP checkout (raw HTTP)', () => {
+    it('should reject requests without auth', async () => {
+      const res = await fetch(`${merchant.baseUrl}/checkout_sessions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ line_items: [{ product_id: 'prod_webcam', quantity: 1 }] }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('should create a checkout session with auth', async () => {
+      const res = await fetch(`${merchant.baseUrl}/checkout_sessions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${merchant.requiredApiKey}`,
+          'API-Version': '2026-01-30',
+        },
+        body: JSON.stringify({ line_items: [{ product_id: 'prod_webcam', quantity: 2 }] }),
+      });
+      expect(res.status).toBe(201);
+      const session = await res.json();
+      expect(session.id).toBeDefined();
+      expect(session.status).toBe('not_ready_for_payment');
+      expect(session.line_items).toHaveLength(1);
+      expect(session.line_items[0].quantity).toBe(2);
+      expect(session.totals.subtotal.amount).toBe(7999 * 2);
+      expect(session.payment_handlers).toBeDefined();
+      expect(session.links).toBeDefined();
+    });
+  });
+});
+
+describe('AcpClient', () => {
+  let merchant: MockAcpMerchant;
+  let client: AcpClient;
+
+  beforeAll(async () => {
+    merchant = new MockAcpMerchant({ name: 'ACP Client Test' });
+    await merchant.start();
+    client = new AcpClient({
+      endpoint: merchant.acpEndpoint,
+      apiKey: merchant.requiredApiKey,
+    });
+  });
+
+  afterAll(async () => {
+    await merchant.stop();
+  });
+
+  describe('createCheckout()', () => {
+    it('should create a checkout session', async () => {
+      const session = await client.createCheckout({
+        line_items: [{ product_id: 'prod_laptop_stand', quantity: 1 }],
+      });
+
+      expect(session.id).toBeDefined();
+      expect(session.id).toMatch(/^cs_/);
+      expect(session.status).toBe('not_ready_for_payment');
+      expect(session.line_items).toHaveLength(1);
+      expect(session.line_items[0].name).toContain('Laptop Stand');
+      expect(session.totals.subtotal.amount).toBe(5999);
+      expect(session.totals.subtotal.currency).toBe('USD');
+    });
+
+    it('should reject empty line items', async () => {
+      await expect(
+        client.createCheckout({ line_items: [] })
+      ).rejects.toThrow(AcpApiError);
+    });
+
+    it('should reject unknown product IDs', async () => {
+      await expect(
+        client.createCheckout({ line_items: [{ product_id: 'nonexistent', quantity: 1 }] })
+      ).rejects.toThrow(AcpApiError);
+    });
+  });
+
+  describe('getCheckout()', () => {
+    it('should retrieve an existing session', async () => {
+      const created = await client.createCheckout({
+        line_items: [{ product_id: 'prod_usb_hub', quantity: 3 }],
+      });
+
+      const retrieved = await client.getCheckout(created.id);
+      expect(retrieved.id).toBe(created.id);
+      expect(retrieved.status).toBe(created.status);
+      expect(retrieved.line_items).toHaveLength(1);
+    });
+
+    it('should throw for nonexistent session', async () => {
+      await expect(
+        client.getCheckout('cs_nonexistent')
+      ).rejects.toThrow(AcpApiError);
+    });
+  });
+
+  describe('updateCheckout()', () => {
+    it('should add shipping address and transition to ready_for_payment', async () => {
+      const session = await client.createCheckout({
+        line_items: [{ product_id: 'prod_webcam', quantity: 1 }],
+      });
+      expect(session.status).toBe('not_ready_for_payment');
+
+      const updated = await client.updateCheckout(session.id, {
+        shipping_address: {
+          name: 'Jane Doe',
+          line1: '456 Oak Ave',
+          city: 'Austin',
+          state: 'TX',
+          postal_code: '73301',
+          country: 'US',
+        },
+      });
+
+      expect(updated.status).toBe('ready_for_payment');
+      expect(updated.shipping_address).toBeDefined();
+      expect(updated.shipping_address!.name).toBe('Jane Doe');
+      expect(updated.totals.shipping).toBeDefined();
+      expect(updated.totals.total.amount).toBeGreaterThan(updated.totals.subtotal.amount);
+    });
+  });
+
+  describe('completeCheckout()', () => {
+    it('should complete a full checkout flow', async () => {
+      // Create
+      const session = await client.createCheckout({
+        line_items: [{ product_id: 'prod_desk_mat', quantity: 2 }],
+      });
+
+      // Add shipping
+      await client.updateCheckout(session.id, {
+        shipping_address: {
+          name: 'Test User',
+          line1: '123 Main St',
+          city: 'San Francisco',
+          state: 'CA',
+          postal_code: '94105',
+          country: 'US',
+        },
+      });
+
+      // Complete
+      const completed = await client.completeCheckout(session.id, {
+        payment_token: 'tok_mock_success',
+        payment_handler: 'stripe_shared_payment_token',
+      });
+
+      expect(completed.status).toBe('completed');
+    });
+
+    it('should reject completion without shipping', async () => {
+      const session = await client.createCheckout({
+        line_items: [{ product_id: 'prod_webcam', quantity: 1 }],
+      });
+
+      // Try to complete without shipping — status is not_ready_for_payment
+      await expect(
+        client.completeCheckout(session.id, {
+          payment_token: 'tok_mock_success',
+          payment_handler: 'stripe_shared_payment_token',
+        })
+      ).rejects.toThrow(AcpApiError);
+    });
+
+    it('should reject failed payment token', async () => {
+      const session = await client.createCheckout({
+        line_items: [{ product_id: 'prod_webcam', quantity: 1 }],
+      });
+      await client.updateCheckout(session.id, {
+        shipping_address: {
+          name: 'Test',
+          line1: '123 St',
+          city: 'NYC',
+          state: 'NY',
+          postal_code: '10001',
+          country: 'US',
+        },
+      });
+
+      await expect(
+        client.completeCheckout(session.id, {
+          payment_token: 'tok_mock_failure',
+          payment_handler: 'stripe_shared_payment_token',
+        })
+      ).rejects.toThrow(AcpApiError);
+    });
+  });
+
+  describe('cancelCheckout()', () => {
+    it('should cancel an active session', async () => {
+      const session = await client.createCheckout({
+        line_items: [{ product_id: 'prod_cable_organizer', quantity: 5 }],
+      });
+
+      const canceled = await client.cancelCheckout(session.id);
+      expect(canceled.status).toBe('canceled');
+    });
+
+    it('should reject canceling a completed session', async () => {
+      const session = await client.createCheckout({
+        line_items: [{ product_id: 'prod_phone_charger', quantity: 1 }],
+      });
+      await client.updateCheckout(session.id, {
+        shipping_address: {
+          name: 'Test',
+          line1: '1 St',
+          city: 'LA',
+          state: 'CA',
+          postal_code: '90001',
+          country: 'US',
+        },
+      });
+      await client.completeCheckout(session.id, {
+        payment_token: 'tok_mock_success',
+        payment_handler: 'stripe_shared_payment_token',
+      });
+
+      await expect(
+        client.cancelCheckout(session.id)
+      ).rejects.toThrow(AcpApiError);
+    });
+  });
+
+  describe('authentication', () => {
+    it('should reject invalid API key', async () => {
+      const badClient = new AcpClient({
+        endpoint: merchant.acpEndpoint,
+        apiKey: 'wrong_key',
+      });
+
+      await expect(
+        badClient.createCheckout({
+          line_items: [{ product_id: 'prod_webcam', quantity: 1 }],
+        })
+      ).rejects.toThrow(AcpApiError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `AcpClient` class implementing all 5 ACP checkout session endpoints (create, get, update, complete, cancel) with Bearer token auth
- Add `MockAcpMerchant` Express test server with product catalog and full ACP checkout state machine
- Update `ShoppingAgent` for dual-protocol support: auto-detects UCP vs ACP on discovery, routes all tool operations to the correct protocol
- 28 new tests (113 total) covering AcpClient, MockAcpMerchant, agent ACP flows, and protocol detection

## Test plan
- [x] All 113 tests pass (`npm test`)
- [x] TypeScript build clean (`npm run build`)
- [x] AcpClient: checkout CRUD, auth failures, error handling
- [x] MockAcpMerchant: product API, checkout state machine, payment simulation
- [x] ShoppingAgent: ACP discovery, browse, search, full checkout flow, capabilities
- [x] Protocol detection: UCP preferred, ACP fallback, error when neither works

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)