### PR TITLE
chore: v0.3.0 release — landing page + version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agorio/sdk",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "The open-source toolkit for building AI commerce agents using UCP and ACP protocols",
   "type": "module",
   "main": "dist/index.js",

--- a/site/components/Adapters.tsx
+++ b/site/components/Adapters.tsx
@@ -26,7 +26,12 @@ const agent = new ShoppingAgent({
   llm: new GeminiAdapter({ apiKey: process.env.GEMINI_API_KEY }),
   // llm: new ClaudeAdapter({ apiKey: process.env.ANTHROPIC_API_KEY }),
   // llm: new OpenAIAdapter({ apiKey: process.env.OPENAI_API_KEY }),
-});`;
+});
+
+// Stream results in real time
+for await (const event of agent.runStream("Buy headphones")) {
+  if (event.type === 'text_delta') process.stdout.write(event.text);
+}`;
 
 export default function Adapters() {
   return (
@@ -35,7 +40,7 @@ export default function Adapters() {
         Works with any LLM
       </h2>
       <p className="text-center text-[var(--muted)] mb-12 max-w-2xl mx-auto">
-        Three adapters ship out of the box. Implement the{' '}
+        Three adapters ship out of the box — all with streaming support. Implement the{' '}
         <code className="text-[var(--accent)] bg-[var(--code-bg)] px-1.5 py-0.5 rounded text-xs">
           LlmAdapter
         </code>{' '}

--- a/site/components/CodeBlock.tsx
+++ b/site/components/CodeBlock.tsx
@@ -19,7 +19,7 @@ function highlightSyntax(code: string): string {
     )
     // Types/classes
     .replace(
-      /\b(ShoppingAgent|GeminiAdapter|ClaudeAdapter|OpenAIAdapter|MockMerchant|UcpClient|Promise)\b/g,
+      /\b(ShoppingAgent|GeminiAdapter|ClaudeAdapter|OpenAIAdapter|MockMerchant|MockAcpMerchant|UcpClient|AcpClient|Promise)\b/g,
       '<span class="token-type">$1</span>',
     )
     // Properties/methods

--- a/site/components/Hero.tsx
+++ b/site/components/Hero.tsx
@@ -25,7 +25,7 @@ export default function Hero() {
         <div>
           <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-[var(--border)] text-sm text-[var(--muted)] mb-6">
             <span className="w-2 h-2 rounded-full bg-emerald-500" />
-            v0.2 — Gemini, Claude, OpenAI
+            v0.3 — UCP + ACP · Streaming · Gemini, Claude, OpenAI
           </div>
 
           <h1 className="text-4xl sm:text-5xl font-bold leading-tight tracking-tight mb-6">

--- a/site/components/Tools.tsx
+++ b/site/components/Tools.tsx
@@ -1,5 +1,5 @@
 const tools = [
-  { name: 'discover_merchant', desc: 'Fetch and parse a UCP profile by domain', icon: '🔍' },
+  { name: 'discover_merchant', desc: 'Auto-detect UCP or ACP merchant by domain', icon: '🔍' },
   { name: 'list_capabilities', desc: 'List what the merchant supports', icon: '📋' },
   { name: 'browse_products', desc: 'Paginated catalog with filtering', icon: '🛒' },
   { name: 'search_products', desc: 'Keyword search across products', icon: '🔎' },
@@ -20,8 +20,8 @@ export default function Tools() {
         12 Built-in Shopping Tools
       </h2>
       <p className="text-center text-[var(--muted)] mb-12 max-w-2xl mx-auto">
-        Every tool the agent needs for the full UCP shopping workflow — from
-        discovery to order tracking.
+        Every tool the agent needs for the full shopping workflow — UCP and ACP,
+        from discovery to order tracking.
       </p>
 
       <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">

--- a/site/components/WhyAgorio.tsx
+++ b/site/components/WhyAgorio.tsx
@@ -1,8 +1,8 @@
 const comparisons = [
   {
-    capability: 'UCP merchant discovery',
-    scratch: 'Parse /.well-known/ucp yourself, handle both capability formats, normalize services',
-    agorio: 'client.discover("shop.example.com")',
+    capability: 'Merchant discovery',
+    scratch: 'Parse /.well-known/ucp yourself, handle ACP endpoints separately, detect protocol',
+    agorio: 'Auto-detects UCP or ACP per merchant',
   },
   {
     capability: 'Product search',
@@ -22,7 +22,7 @@ const comparisons = [
   {
     capability: 'Testing',
     scratch: 'Stand up your own mock server, write fixtures',
-    agorio: 'new MockMerchant() — full UCP server',
+    agorio: 'MockMerchant (UCP) + MockAcpMerchant (ACP)',
   },
   {
     capability: 'Agent orchestration',
@@ -37,21 +37,21 @@ export default function WhyAgorio() {
       <h2 className="text-3xl font-bold text-center mb-4">
         Why Agorio
       </h2>
-      <p className="text-center text-[var(--muted)] mb-12 max-w-2xl mx-auto">
+      <p className="text-center text-(--muted) mb-12 max-w-2xl mx-auto">
         Stop rebuilding commerce plumbing. Focus on what makes your agent unique.
       </p>
 
       <div className="overflow-x-auto">
         <table className="w-full text-sm border-collapse">
           <thead>
-            <tr className="border-b border-[var(--border)]">
-              <th className="text-left py-3 px-4 text-[var(--muted)] font-medium">
+            <tr className="border-b border-(--border)">
+              <th className="text-left py-3 px-4 text-(--muted) font-medium">
                 Capability
               </th>
-              <th className="text-left py-3 px-4 text-[var(--muted)] font-medium">
+              <th className="text-left py-3 px-4 text-(--muted) font-medium">
                 Building from Scratch
               </th>
-              <th className="text-left py-3 px-4 text-[var(--accent)] font-medium">
+              <th className="text-left py-3 px-4 text-(--accent) font-medium">
                 With Agorio
               </th>
             </tr>
@@ -60,12 +60,12 @@ export default function WhyAgorio() {
             {comparisons.map((row) => (
               <tr
                 key={row.capability}
-                className="border-b border-[var(--border)] hover:bg-[var(--card)] transition-colors"
+                className="border-b border-(--border) hover:bg-(--card) transition-colors"
               >
                 <td className="py-3 px-4 font-medium">{row.capability}</td>
-                <td className="py-3 px-4 text-[var(--muted)]">{row.scratch}</td>
+                <td className="py-3 px-4 text-(--muted)">{row.scratch}</td>
                 <td className="py-3 px-4">
-                  <code className="text-[var(--accent)] bg-[var(--code-bg)] px-1.5 py-0.5 rounded text-xs">
+                  <code className="text-(--accent) bg-(--code-bg) px-1.5 py-0.5 rounded text-xs">
                     {row.agorio}
                   </code>
                 </td>


### PR DESCRIPTION
## Summary
- Bump package version from 0.2.1 to 0.3.0
- Update landing page to reflect ACP, streaming, and dual-protocol support:
  - Hero badge: v0.3 with UCP + ACP + Streaming
  - WhyAgorio: dual-protocol discovery, MockAcpMerchant for testing
  - Adapters: streaming mention + `runStream()` code example
  - Tools: dual-protocol descriptions
  - CodeBlock: syntax highlighting for AcpClient, MockAcpMerchant
- Update README: shipped features, 113 tests, architecture, project structure
- Tailwind canonical class cleanup (WhyAgorio.tsx)

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 113 tests pass
- [ ] Visual check of landing page after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)