### PR TITLE
feat: Add Ollama adapter for local/offline agents

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,8 @@ export { ClaudeAdapter } from './llm/claude.js';
 export type { ClaudeAdapterOptions } from './llm/claude.js';
 export { OpenAIAdapter } from './llm/openai.js';
 export type { OpenAIAdapterOptions } from './llm/openai.js';
+export { OllamaAdapter } from './llm/ollama.js';
+export type { OllamaAdapterOptions } from './llm/ollama.js';
 
 // Agent
 export { ShoppingAgent } from './agent/shopping-agent.js';

--- a/src/llm/ollama.ts
+++ b/src/llm/ollama.ts
@@ -1,0 +1,278 @@
+/**
+ * Ollama LLM Adapter
+ *
+ * Integrates local Ollama models with function calling support
+ * via Ollama's OpenAI-compatible API endpoint.
+ *
+ * Requires Ollama running locally: https://ollama.com
+ * No API key needed — runs entirely on your machine.
+ */
+
+import OpenAI from 'openai';
+import type {
+  LlmAdapter,
+  ChatMessage,
+  ToolDefinition,
+  ToolCall,
+  LlmResponse,
+  LlmStreamChunk,
+} from '../types/index.js';
+
+export interface OllamaAdapterOptions {
+  /** Model name (default: llama3.1) */
+  model?: string;
+  /** Ollama server URL (default: http://localhost:11434/v1) */
+  baseUrl?: string;
+  /** System prompt for the model */
+  systemPrompt?: string;
+  /** Temperature (0-2, default: 0.7) */
+  temperature?: number;
+  /** Maximum tokens to generate (default: 4096) */
+  maxTokens?: number;
+}
+
+export class OllamaAdapter implements LlmAdapter {
+  private readonly client: OpenAI;
+  readonly modelName: string;
+  private readonly systemPrompt: string;
+  private readonly temperature: number;
+  private readonly maxTokens: number;
+
+  constructor(options: OllamaAdapterOptions = {}) {
+    this.modelName = options.model ?? 'llama3.1';
+    this.temperature = options.temperature ?? 0.7;
+    this.maxTokens = options.maxTokens ?? 4096;
+    this.systemPrompt = options.systemPrompt ?? this.getDefaultSystemPrompt();
+
+    this.client = new OpenAI({
+      baseURL: options.baseUrl ?? 'http://localhost:11434/v1',
+      apiKey: 'ollama', // Ollama doesn't require a key but the SDK needs a value
+    });
+  }
+
+  async chat(messages: ChatMessage[], tools?: ToolDefinition[]): Promise<LlmResponse> {
+    const ollamaMessages = this.toOpenAIMessages(messages);
+    const ollamaTools = tools?.length ? this.toOpenAITools(tools) : undefined;
+
+    const response = await this.client.chat.completions.create({
+      model: this.modelName,
+      max_tokens: this.maxTokens,
+      messages: ollamaMessages,
+      ...(ollamaTools ? { tools: ollamaTools } : {}),
+      temperature: this.temperature,
+    });
+
+    return this.parseResponse(response);
+  }
+
+  async *chatStream(messages: ChatMessage[], tools?: ToolDefinition[]): AsyncGenerator<LlmStreamChunk> {
+    const ollamaMessages = this.toOpenAIMessages(messages);
+    const ollamaTools = tools?.length ? this.toOpenAITools(tools) : undefined;
+
+    const stream = await this.client.chat.completions.create({
+      model: this.modelName,
+      max_tokens: this.maxTokens,
+      messages: ollamaMessages,
+      ...(ollamaTools ? { tools: ollamaTools } : {}),
+      temperature: this.temperature,
+      stream: true,
+    });
+
+    let content = '';
+    const toolCalls: ToolCall[] = [];
+    const toolAccumulators = new Map<number, { id: string; name: string; args: string }>();
+
+    for await (const chunk of stream) {
+      const choice = chunk.choices[0];
+      if (!choice) continue;
+
+      const delta = choice.delta;
+
+      if (delta.content) {
+        content += delta.content;
+        yield { type: 'text_delta', text: delta.content };
+      }
+
+      if (delta.tool_calls) {
+        for (const tc of delta.tool_calls) {
+          const idx = tc.index;
+          if (!toolAccumulators.has(idx)) {
+            toolAccumulators.set(idx, {
+              id: tc.id ?? '',
+              name: tc.function?.name ?? '',
+              args: '',
+            });
+            yield {
+              type: 'tool_call_start',
+              toolCallId: tc.id ?? '',
+              toolName: tc.function?.name ?? '',
+            };
+          }
+          const acc = toolAccumulators.get(idx)!;
+          if (tc.id) acc.id = tc.id;
+          if (tc.function?.name) acc.name = tc.function.name;
+          if (tc.function?.arguments) {
+            acc.args += tc.function.arguments;
+            yield {
+              type: 'tool_call_delta',
+              toolCallId: acc.id,
+              argsDelta: tc.function.arguments,
+            };
+          }
+        }
+      }
+
+      if (choice.finish_reason) {
+        for (const [, acc] of toolAccumulators) {
+          const tc: ToolCall = {
+            id: acc.id,
+            name: acc.name,
+            arguments: acc.args ? JSON.parse(acc.args) : {},
+          };
+          toolCalls.push(tc);
+          yield { type: 'tool_call_complete', toolCall: tc };
+        }
+        toolAccumulators.clear();
+      }
+    }
+
+    yield {
+      type: 'done',
+      response: {
+        content,
+        toolCalls,
+        finishReason: toolCalls.length > 0 ? 'tool_calls' : 'stop',
+      },
+    };
+  }
+
+  // ─── Internal helpers ───
+
+  private toOpenAIMessages(messages: ChatMessage[]): OpenAI.ChatCompletionMessageParam[] {
+    const result: OpenAI.ChatCompletionMessageParam[] = [];
+    result.push({ role: 'system', content: this.systemPrompt });
+
+    const toolIdQueues = new Map<string, string[]>();
+
+    for (const msg of messages) {
+      if (msg.role === 'system') continue;
+
+      if (msg.role === 'user') {
+        result.push({ role: 'user', content: msg.content });
+        continue;
+      }
+
+      if (msg.role === 'assistant') {
+        const toolCalls = msg.toolCalls?.map(tc => {
+          if (!toolIdQueues.has(tc.name)) {
+            toolIdQueues.set(tc.name, []);
+          }
+          toolIdQueues.get(tc.name)!.push(tc.id);
+
+          return {
+            id: tc.id,
+            type: 'function' as const,
+            function: {
+              name: tc.name,
+              arguments: JSON.stringify(tc.arguments),
+            },
+          };
+        });
+
+        result.push({
+          role: 'assistant',
+          content: msg.content || null,
+          ...(toolCalls?.length ? { tool_calls: toolCalls } : {}),
+        });
+        continue;
+      }
+
+      if (msg.role === 'tool') {
+        let toolCallId = msg.toolCallId ?? 'unknown';
+
+        const queue = toolIdQueues.get(toolCallId);
+        if (queue && queue.length > 0) {
+          toolCallId = queue.shift()!;
+        }
+
+        result.push({
+          role: 'tool',
+          content: msg.content,
+          tool_call_id: toolCallId,
+        });
+        continue;
+      }
+    }
+
+    return result;
+  }
+
+  private toOpenAITools(tools: ToolDefinition[]): OpenAI.ChatCompletionTool[] {
+    return tools.map(tool => ({
+      type: 'function' as const,
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+      },
+    }));
+  }
+
+  private parseResponse(response: OpenAI.ChatCompletion): LlmResponse {
+    const choice = response.choices[0];
+
+    if (!choice) {
+      return { content: '', toolCalls: [], finishReason: 'error' };
+    }
+
+    const content = choice.message.content ?? '';
+    const toolCalls: ToolCall[] = (choice.message.tool_calls ?? [])
+      .filter((tc): tc is Extract<typeof tc, { type: 'function' }> => tc.type === 'function')
+      .map(tc => ({
+        id: tc.id,
+        name: tc.function.name,
+        arguments: JSON.parse(tc.function.arguments) as Record<string, unknown>,
+      }));
+
+    let finishReason: LlmResponse['finishReason'];
+    switch (choice.finish_reason) {
+      case 'stop':
+        finishReason = 'stop';
+        break;
+      case 'tool_calls':
+        finishReason = 'tool_calls';
+        break;
+      case 'length':
+        finishReason = 'length';
+        break;
+      default:
+        finishReason = toolCalls.length > 0 ? 'tool_calls' : 'stop';
+    }
+
+    return {
+      content,
+      toolCalls,
+      finishReason,
+      usage: response.usage
+        ? {
+            promptTokens: response.usage.prompt_tokens,
+            completionTokens: response.usage.completion_tokens,
+            totalTokens: response.usage.total_tokens,
+          }
+        : undefined,
+    };
+  }
+
+  private getDefaultSystemPrompt(): string {
+    return `You are a UCP Shopping Agent — an AI assistant that helps users discover and purchase products from UCP-enabled and ACP-enabled merchants.
+
+You interact with merchants through the Universal Commerce Protocol (UCP) and Agentic Commerce Protocol (ACP). Your workflow:
+1. Discover the merchant by fetching their UCP profile or connecting via ACP
+2. Browse their product catalog
+3. Help the user find what they need
+4. Complete the checkout process when requested
+
+Always be helpful, transparent about prices, and confirm before completing purchases.
+When you have enough information to proceed, use the available tools. When you need clarification, ask the user.`;
+  }
+}

--- a/tests/ollama-adapter.test.ts
+++ b/tests/ollama-adapter.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Tests for OllamaAdapter - Local Ollama LLM integration
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OllamaAdapter } from '../src/llm/ollama.js';
+import type { ChatMessage, ToolDefinition } from '../src/types/index.js';
+
+// Mock the OpenAI SDK (Ollama uses OpenAI-compatible API)
+const mockCreate = vi.fn();
+
+vi.mock('openai', () => {
+  return {
+    default: class MockOpenAI {
+      chat = {
+        completions: { create: mockCreate },
+      };
+      constructor(public opts?: unknown) {}
+    },
+  };
+});
+
+function makeOllamaResponse(overrides: {
+  content?: string | null;
+  tool_calls?: Array<{ id: string; type: 'function'; function: { name: string; arguments: string } }>;
+  finish_reason?: string;
+  usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+}) {
+  return {
+    id: 'chatcmpl-test',
+    object: 'chat.completion',
+    model: 'llama3.1',
+    choices: [{
+      index: 0,
+      message: {
+        role: 'assistant',
+        content: overrides.content ?? 'Hello',
+        tool_calls: overrides.tool_calls ?? undefined,
+      },
+      finish_reason: overrides.finish_reason ?? 'stop',
+    }],
+    usage: overrides.usage ?? { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+  };
+}
+
+describe('OllamaAdapter', () => {
+  let adapter: OllamaAdapter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new OllamaAdapter();
+  });
+
+  // ─── Constructor ───
+
+  describe('constructor', () => {
+    it('should set default model name', () => {
+      expect(adapter.modelName).toBe('llama3.1');
+    });
+
+    it('should accept custom model name', () => {
+      const custom = new OllamaAdapter({ model: 'mistral' });
+      expect(custom.modelName).toBe('mistral');
+    });
+
+    it('should use default baseUrl for Ollama', () => {
+      // The OpenAI client is constructed with Ollama's default URL
+      const a = new OllamaAdapter();
+      // Verify it works (doesn't throw) — the mock handles the rest
+      expect(a.modelName).toBe('llama3.1');
+    });
+
+    it('should accept custom baseUrl', () => {
+      const custom = new OllamaAdapter({ baseUrl: 'http://remote-server:11434/v1' });
+      expect(custom.modelName).toBe('llama3.1');
+    });
+
+    it('should not require any options', () => {
+      const a = new OllamaAdapter();
+      expect(a.modelName).toBe('llama3.1');
+    });
+  });
+
+  // ─── Response Parsing ───
+
+  describe('response parsing', () => {
+    it('should parse text-only response', async () => {
+      mockCreate.mockResolvedValueOnce(makeOllamaResponse({
+        content: 'The merchant sells electronics.',
+        finish_reason: 'stop',
+      }));
+
+      const result = await adapter.chat([{ role: 'user', content: 'Hi' }]);
+
+      expect(result.content).toBe('The merchant sells electronics.');
+      expect(result.toolCalls).toHaveLength(0);
+      expect(result.finishReason).toBe('stop');
+    });
+
+    it('should parse tool_calls response', async () => {
+      mockCreate.mockResolvedValueOnce(makeOllamaResponse({
+        content: 'Let me discover that merchant.',
+        tool_calls: [{
+          id: 'call_abc123',
+          type: 'function',
+          function: {
+            name: 'discover_merchant',
+            arguments: '{"domain":"shop.example.com"}',
+          },
+        }],
+        finish_reason: 'tool_calls',
+      }));
+
+      const result = await adapter.chat([{ role: 'user', content: 'Discover shop.example.com' }]);
+
+      expect(result.content).toBe('Let me discover that merchant.');
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0]).toEqual({
+        id: 'call_abc123',
+        name: 'discover_merchant',
+        arguments: { domain: 'shop.example.com' },
+      });
+      expect(result.finishReason).toBe('tool_calls');
+    });
+
+    it('should parse multiple tool calls', async () => {
+      mockCreate.mockResolvedValueOnce(makeOllamaResponse({
+        content: null,
+        tool_calls: [
+          {
+            id: 'call_01',
+            type: 'function',
+            function: { name: 'search_products', arguments: '{"query":"headphones"}' },
+          },
+          {
+            id: 'call_02',
+            type: 'function',
+            function: { name: 'browse_products', arguments: '{"limit":5}' },
+          },
+        ],
+        finish_reason: 'tool_calls',
+      }));
+
+      const result = await adapter.chat([{ role: 'user', content: 'Find headphones' }]);
+
+      expect(result.toolCalls).toHaveLength(2);
+      expect(result.toolCalls[0].name).toBe('search_products');
+      expect(result.toolCalls[1].name).toBe('browse_products');
+    });
+
+    it('should map length finish_reason', async () => {
+      mockCreate.mockResolvedValueOnce(makeOllamaResponse({
+        finish_reason: 'length',
+      }));
+
+      const result = await adapter.chat([{ role: 'user', content: 'Hi' }]);
+      expect(result.finishReason).toBe('length');
+    });
+
+    it('should map usage tokens correctly', async () => {
+      mockCreate.mockResolvedValueOnce(makeOllamaResponse({
+        usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+      }));
+
+      const result = await adapter.chat([{ role: 'user', content: 'Hi' }]);
+
+      expect(result.usage).toEqual({
+        promptTokens: 100,
+        completionTokens: 50,
+        totalTokens: 150,
+      });
+    });
+
+    it('should handle missing choices gracefully', async () => {
+      mockCreate.mockResolvedValueOnce({
+        id: 'chatcmpl-test',
+        choices: [],
+        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      });
+
+      const result = await adapter.chat([{ role: 'user', content: 'Hi' }]);
+      expect(result.finishReason).toBe('error');
+      expect(result.content).toBe('');
+    });
+  });
+
+  // ─── Message Conversion ───
+
+  describe('message conversion', () => {
+    it('should prepend system prompt', async () => {
+      mockCreate.mockResolvedValueOnce(makeOllamaResponse({}));
+
+      await adapter.chat([{ role: 'user', content: 'Hello' }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.messages[0].role).toBe('system');
+      expect(callArgs.messages[0].content).toContain('Shopping Agent');
+      expect(callArgs.messages[1]).toEqual({ role: 'user', content: 'Hello' });
+    });
+
+    it('should skip inline system messages', async () => {
+      mockCreate.mockResolvedValueOnce(makeOllamaResponse({}));
+
+      await adapter.chat([
+        { role: 'system', content: 'Extra system.' },
+        { role: 'user', content: 'Hello' },
+      ]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.messages).toHaveLength(2);
+      expect(callArgs.messages[0].role).toBe('system');
+      expect(callArgs.messages[1].role).toBe('user');
+    });
+
+    it('should convert assistant messages with tool calls', async () => {
+      mockCreate.mockResolvedValueOnce(makeOllamaResponse({}));
+
+      const messages: ChatMessage[] = [
+        { role: 'user', content: 'Discover example.com' },
+        {
+          role: 'assistant',
+          content: 'Let me discover that.',
+          toolCalls: [{
+            id: 'call_abc',
+            name: 'discover_merchant',
+            arguments: { domain: 'example.com' },
+          }],
+        },
+        {
+          role: 'tool',
+          content: '{"domain":"example.com"}',
+          toolCallId: 'discover_merchant',
+        },
+      ];
+
+      await adapter.chat(messages);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.messages).toHaveLength(4);
+
+      const assistantMsg = callArgs.messages[2];
+      expect(assistantMsg.role).toBe('assistant');
+      expect(assistantMsg.tool_calls).toHaveLength(1);
+      expect(assistantMsg.tool_calls[0]).toEqual({
+        id: 'call_abc',
+        type: 'function',
+        function: {
+          name: 'discover_merchant',
+          arguments: '{"domain":"example.com"}',
+        },
+      });
+
+      const toolMsg = callArgs.messages[3];
+      expect(toolMsg.role).toBe('tool');
+      expect(toolMsg.tool_call_id).toBe('call_abc');
+    });
+
+    it('should resolve name-based toolCallId to actual tool_call_id', async () => {
+      mockCreate.mockResolvedValueOnce(makeOllamaResponse({}));
+
+      const messages: ChatMessage[] = [
+        { role: 'user', content: 'Search' },
+        {
+          role: 'assistant',
+          content: '',
+          toolCalls: [{
+            id: 'call_REAL_ID',
+            name: 'search_products',
+            arguments: { query: 'test' },
+          }],
+        },
+        {
+          role: 'tool',
+          content: '{"products":[]}',
+          toolCallId: 'search_products',
+        },
+      ];
+
+      await adapter.chat(messages);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      const toolMsg = callArgs.messages[3];
+      expect(toolMsg.tool_call_id).toBe('call_REAL_ID');
+    });
+
+    it('should handle same tool called twice with correct ID resolution', async () => {
+      mockCreate.mockResolvedValueOnce(makeOllamaResponse({}));
+
+      const messages: ChatMessage[] = [
+        { role: 'user', content: 'Add two items' },
+        {
+          role: 'assistant',
+          content: '',
+          toolCalls: [
+            { id: 'call_FIRST', name: 'add_to_cart', arguments: { productId: 'a' } },
+            { id: 'call_SECOND', name: 'add_to_cart', arguments: { productId: 'b' } },
+          ],
+        },
+        { role: 'tool', content: '{"ok":true}', toolCallId: 'add_to_cart' },
+        { role: 'tool', content: '{"ok":true}', toolCallId: 'add_to_cart' },
+      ];
+
+      await adapter.chat(messages);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.messages[3].tool_call_id).toBe('call_FIRST');
+      expect(callArgs.messages[4].tool_call_id).toBe('call_SECOND');
+    });
+  });
+
+  // ─── Tool Definition Conversion ───
+
+  describe('tool definition conversion', () => {
+    it('should convert ToolDefinition to function tool format', async () => {
+      mockCreate.mockResolvedValueOnce(makeOllamaResponse({}));
+
+      const tools: ToolDefinition[] = [{
+        name: 'discover_merchant',
+        description: 'Discover a UCP merchant by domain',
+        parameters: {
+          type: 'object',
+          properties: {
+            domain: { type: 'string', description: 'Merchant domain' },
+          },
+          required: ['domain'],
+        },
+      }];
+
+      await adapter.chat([{ role: 'user', content: 'Hi' }], tools);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.tools).toHaveLength(1);
+      expect(callArgs.tools[0]).toEqual({
+        type: 'function',
+        function: {
+          name: 'discover_merchant',
+          description: 'Discover a UCP merchant by domain',
+          parameters: {
+            type: 'object',
+            properties: {
+              domain: { type: 'string', description: 'Merchant domain' },
+            },
+            required: ['domain'],
+          },
+        },
+      });
+    });
+
+    it('should not pass tools when none provided', async () => {
+      mockCreate.mockResolvedValueOnce(makeOllamaResponse({}));
+
+      await adapter.chat([{ role: 'user', content: 'Hi' }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.tools).toBeUndefined();
+    });
+  });
+
+  // ─── API Call Parameters ───
+
+  describe('API call parameters', () => {
+    it('should pass default parameters', async () => {
+      mockCreate.mockResolvedValueOnce(makeOllamaResponse({}));
+
+      await adapter.chat([{ role: 'user', content: 'Hi' }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.model).toBe('llama3.1');
+      expect(callArgs.max_tokens).toBe(4096);
+      expect(callArgs.temperature).toBe(0.7);
+    });
+
+    it('should use custom options', async () => {
+      const custom = new OllamaAdapter({
+        model: 'mistral',
+        maxTokens: 2048,
+        temperature: 0.3,
+      });
+
+      mockCreate.mockResolvedValueOnce(makeOllamaResponse({}));
+      await custom.chat([{ role: 'user', content: 'Hi' }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.model).toBe('mistral');
+      expect(callArgs.max_tokens).toBe(2048);
+      expect(callArgs.temperature).toBe(0.3);
+    });
+
+    it('should use custom system prompt', async () => {
+      const custom = new OllamaAdapter({
+        systemPrompt: 'You are a test bot.',
+      });
+
+      mockCreate.mockResolvedValueOnce(makeOllamaResponse({}));
+      await custom.chat([{ role: 'user', content: 'Hi' }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.messages[0]).toEqual({ role: 'system', content: 'You are a test bot.' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `OllamaAdapter` for local LLM inference via Ollama's OpenAI-compatible API
- No API key required — uses `http://localhost:11434/v1` by default
- Supports function calling and streaming (`chat()` + `chatStream()`)
- Configurable model, base URL, temperature, max tokens, system prompt
- 21 new tests (134 total)
- No new dependencies — reuses the existing `openai` package

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 134 tests pass
- [x] Constructor: defaults, custom model, custom baseUrl, no-arg construction
- [x] Response parsing: text, tool calls, multiple tools, length, usage, empty choices
- [x] Message conversion: system prompt, tool call ID resolution, duplicate tool handling
- [x] Tool definitions: conversion to function format, omission when empty
- [x] API parameters: defaults, custom options, custom system prompt

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)